### PR TITLE
Support hash-object reading objects from stdin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,17 +145,10 @@ mod tests {
 
     #[test]
     fn test_hash_object() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let path = tmpdir.path().to_path_buf().join("file.txt");
         let mut stdout = Vec::new();
 
         // From https://git-scm.com/book/sv/v2/Git-Internals-Git-Objects
-        std::fs::write(&path, b"test content\n").ok();
-        hash_object(
-            &mut io::BufReader::new(fs::File::open(path).unwrap()),
-            &mut stdout,
-        )
-        .unwrap();
+        hash_object(&mut "test content\n".as_bytes(), &mut stdout).unwrap();
         assert_eq!(stdout, b"d670460b4b4aece5915caf5c68d12f560a9fe3e4\n");
     }
 


### PR DESCRIPTION
```
robin@x code/good_git (hash-object-from-stdin)
$ echo -n "hello" | cargo run -- hash-object --stdin
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/good_git hash-object --stdin`
b6fc4c620b67d95f953a5c1c1230aaab5db5a1b0

robin@x code/good_git (hash-object-from-stdin)
$ echo -n "hello" | git hash-object --stdin
b6fc4c620b67d95f953a5c1c1230aaab5db5a1b0
```