### PR TITLE
Fix tests on Windows; add Windows, macOS CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,14 @@ jobs:
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   cargo-test:
-    runs-on: ubuntu-22.04
+    name: cargo-test-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-14]
+
     steps:
       - uses: actions/checkout@v4
       - run: cargo --version

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -34,7 +34,12 @@ mod tests {
 
     #[test]
     fn test_from_dir_in_sub_dir() {
-        let tmpdir = tempfile::tempdir().unwrap().path().to_path_buf();
+        let tmpdir = tempfile::tempdir()
+            .unwrap()
+            .path()
+            .to_path_buf()
+            .canonicalize()
+            .unwrap();
         let git_dir = tmpdir.join(GIT_FOLDER_NAME);
         std::fs::create_dir_all(&git_dir).unwrap();
 


### PR DESCRIPTION
```
thread 'repo::tests::test_from_dir_in_sub_dir' panicked at src\repo.rs:47:9:
assertion `left == right` failed
  left: "C:\\Users\\r\\AppData\\Local\\Temp\\.tmpQ425qG\\.git"
 right: "\\\\?\\C:\\Users\\r\\AppData\\Local\\Temp\\.tmpQ425qG\\.git"
```