### PR TITLE
Add support to print trees with cat-file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,18 @@ fn cat_file(repo: &Repo, object_hash: &str, stdout: &mut dyn io::Write) -> Resul
             let content = std::str::from_utf8(&blob.content)?;
             writeln!(stdout, "{content}")?;
         }
+        Object::Tree(tree) => {
+            for file in tree.files {
+                writeln!(
+                    stdout,
+                    "{:>6} {:>4} {:43} {}",
+                    file.mode,
+                    file.type_str(),
+                    file.hash,
+                    file.name
+                )?;
+            }
+        }
     }
 
     Ok(())

--- a/src/object.rs
+++ b/src/object.rs
@@ -24,14 +24,52 @@ impl Blob {
 }
 
 #[derive(Debug)]
+pub struct Tree {
+    pub files: Vec<File>,
+}
+
+impl Tree {
+    pub fn new(files: Vec<File>) -> Tree {
+        Tree { files }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct File {
+    pub mode: String,
+    pub name: String,
+    pub hash: String,
+}
+
+impl File {
+    pub fn type_str(&self) -> &str {
+        // Possible values:
+        // 100644: normal file (blob)
+        // 100755: executable file (blob)
+        // 120000: symbolic link
+        // 40000: tree
+        // 160000: submodule
+        match self.mode.as_str() {
+            "100644" => "blob",
+            "100755" => "blob",
+            "120000" => "symlink",
+            "40000" => "tree",
+            "160000" => "submodule",
+            _ => "unknown",
+        }
+    }
+}
+
+#[derive(Debug)]
 pub enum Object {
     Blob(Blob),
+    Tree(Tree),
 }
 
 impl Object {
     pub fn from_bytes(s: &[u8]) -> Result<Object> {
         let (object_type, object_size, header_end) = Object::parse_header(s)?;
-        let content = &s[header_end + 1..];
+        let mut content = &s[header_end + 1..];
 
         if content.len() != object_size {
             return Err(anyhow!("Incorrect header length"));
@@ -41,6 +79,38 @@ impl Object {
             "blob" => {
                 let blob = Blob::new(content.to_vec());
                 Ok(Object::Blob(blob))
+            }
+            "tree" => {
+                // Format (one per file/folder/tree/submodule):
+                // [mode] [object name]\0[SHA-1 in binary format (20 bytes)]
+                let mut files = vec![];
+                while !content.is_empty() {
+                    let mut mode = vec![];
+                    let mode_size = content
+                        .read_until(b' ', &mut mode)
+                        .context("Failed to read mode")?;
+                    let mode = std::str::from_utf8(&mode[..mode_size - 1])?;
+
+                    let mut name = vec![];
+                    let name_size = content
+                        .read_until(b'\0', &mut name)
+                        .context("Failed to read file name")?;
+                    let name = std::str::from_utf8(&name[..name_size - 1])?;
+
+                    let mut hash = [0_u8; 20];
+                    content
+                        .read_exact(&mut hash)
+                        .context("Failed to read hash")?;
+                    let hash = hex::encode(hash);
+
+                    files.push(File {
+                        mode: mode.to_string(),
+                        name: name.to_string(),
+                        hash,
+                    });
+                }
+                let tree = Tree::new(files);
+                Ok(Object::Tree(tree))
             }
             _ => Err(anyhow!("Unknown object type")),
         }
@@ -85,6 +155,8 @@ pub fn hash(s: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::object::File;
+
     use super::hash;
     use super::Blob;
     use super::Object;
@@ -109,11 +181,53 @@ mod tests {
     }
 
     #[test]
-    fn test_blob_from_bytes() {
+    fn test_object_from_bytes_for_blob() {
         let s = b"blob 16\0what is up, doc?";
         let object = Object::from_bytes(s.as_ref()).unwrap();
-        let Object::Blob(blob) = object;
+        let Object::Blob(blob) = object else {
+            panic!("Expected a Blob");
+        };
         assert_eq!(blob.content, b"what is up, doc?");
+    }
+
+    #[test]
+    fn test_object_from_bytes_for_tree() {
+        let s = b"tree 107\0\
+            100644 file1.txt\0\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\
+            100644 file2.txt\0\x51\x52\x53\x54\x55\x56\x57\x58\x59\x5a\x5b\x5c\x5d\x5e\x5f\x60\x61\x62\x63\x64\
+            40000 folder\0\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94";
+        let object = Object::from_bytes(s.as_ref()).unwrap();
+        let Object::Tree(tree) = object else {
+            panic!("Expected a tree");
+        };
+        assert_eq!(
+            tree.files,
+            vec![
+                File {
+                    mode: "100644".to_string(),
+                    name: "file1.txt".to_string(),
+                    hash: "0102030405060708090a0b0c0d0e0f1011121314".to_string(),
+                },
+                File {
+                    mode: "100644".to_string(),
+                    name: "file2.txt".to_string(),
+                    hash: "5152535455565758595a5b5c5d5e5f6061626364".to_string(),
+                },
+                File {
+                    mode: "40000".to_string(),
+                    name: "folder".to_string(),
+                    hash: "8182838485868788898a8b8c8d8e8f9091929394".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_object_from_bytes_for_tree_incorrect_hash_length() {
+        let s = b"tree 18\0\
+            100644 file1.txt\0\x01";
+        let err = Object::from_bytes(s.as_ref()).unwrap_err().to_string();
+        assert_eq!(err, "Failed to read hash");
     }
 
     #[test]


### PR DESCRIPTION
* Add parsing of tree objects.
* cat-file will now print the contents of a tree object if the object is a tree.