### PR TITLE
Add support to print commits with cat-file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,13 @@ fn cat_file(repo: &Repo, object_hash: &str, stdout: &mut dyn io::Write) -> Resul
                 )?;
             }
         }
+        Object::Commit(commit) => {
+            writeln!(stdout, "tree: {}", commit.tree)?;
+            writeln!(stdout, "parent: {}", commit.parent)?;
+            writeln!(stdout, "author: {}", commit.author)?;
+            writeln!(stdout, "committer: {}", commit.committer)?;
+            writeln!(stdout, "\n{}", commit.message)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
 * Add parsing of commit objects. Only standard headers are parsed right now. Timestamps are not parsed yet.
 * cat-file will now print the contents of a commit object if the object is a commit.